### PR TITLE
fix: mount routers on same base path

### DIFF
--- a/docs/core/Router.md
+++ b/docs/core/Router.md
@@ -26,47 +26,47 @@ The following routing syntax can be used:
 
 <!-- !toc -->
 
-* [Router](#router)
-* [Usage](#usage)
-  * [Mounting Routers](#mounting-routers)
-* [API](#api)
-  * [new Router(routerOptions)](#new-routerrouteroptions)
-  * [method(methods, paths, ...handlers)](#methodmethods-paths-handlers)
-  * [all(paths, ...handlers)](#allpaths-handlers)
-  * [acl|...|get|post|put|delete|...|trace(paths, ...handlers)](#aclgetpostputdeletetracepaths-handlers)
-  * [use(path, ...handlers)](#usepath-handlers)
-  * [handle(req, res, next)](#handlereq-res-next)
-  * [preHook|postHook(...handlers)](#prehookposthookhandlers)
+- [Router](#router)
+- [Usage](#usage)
+  - [Mounting Routers](#mounting-routers)
+- [API](#api)
+  - [new Router(routerOptions)](#new-routerrouteroptions)
+  - [method(methods, paths, ...handlers)](#methodmethods-paths-handlers)
+  - [all(paths, ...handlers)](#allpaths-handlers)
+  - [acl|...|get|post|put|delete|...|trace(paths, ...handlers)](#aclgetpostputdeletetracepaths-handlers)
+  - [use(path, ...handlers)](#usepath-handlers)
+  - [handle(req, res, next)](#handlereq-res-next)
+  - [preHook|postHook(...handlers)](#prehookposthookhandlers)
 
 <!-- toc! -->
 
 # Usage
 
 ```js
-import { Router } from "veloze";
+import { Router } from 'veloze'
 
 // creates a new router instance
-const app = new Router();
+const app = new Router()
 
 // preHook(s) applied to all routes
 app.preHook = (req, res, next) => {
-  const { method, url } = req;
-  res.body = [method, url];
-  next();
-};
+  const { method, url } = req
+  res.body = [method, url]
+  next()
+}
 // postHook is applied to all routes
-app.postHook = (req, res) => res.end(JSON.stringify(res.body));
+app.postHook = (req, res) => res.end(JSON.stringify(res.body))
 
-app.get("/get-it", async (req, res) => res.body.push("#1"));
+app.get('/get-it', async (req, res) => res.body.push('#1'))
 /// ['GET', '/get-it', '#1']
-app.post("/post-it", async (req, res) => res.body.push("#2"));
+app.post('/post-it', async (req, res) => res.body.push('#2'))
 /// ['POST', '/post-it', '#2']
 
 // all other request are handled here
-app.all("/*", (req, res) => res.end());
+app.all('/*', (req, res) => res.end())
 
 // apply handle to serve requests
-http.createServer(app.handle).listen(3000);
+http.createServer(app.handle).listen(3000)
 ```
 
 ## Mounting Routers
@@ -79,24 +79,21 @@ app. Mounting different routers on the same path result in the last router to
 win.
 
 ```js
-import { Router } from "veloze";
+import { Router } from 'veloze'
 
-const router = new Router();
-router.mountPath = "/route";
-router.get("/", (req, res) => {
-  res.end("route");
-});
+const router = new Router()
+router.get('/', (req, res) => {
+  res.end('route')
+})
 
-const app = new Router();
-app.get("/", (req, res) => res.end("home"));
-// mount the router handle on path `/route`
-// **either** use
-app.use(router.mountPath, router.handle);
-// **or** mount directly with 
-app.use(router)
+const app = new Router()
+app.get('/', (req, res) => res.end('home'))
+// mount the router on path `/route`
+// DON'T USE THE `router.handle` here
+app.use('/route', router)
 
 // apply app.handle to serve requests
-http.createServer(app.handle).listen(3000);
+http.createServer(app.handle).listen(3000)
 
 // GET /route -> 'route'
 // GET /      -> 'home'
@@ -118,16 +115,16 @@ http.createServer(app.handle).listen(3000);
 
 ```js
 // router to `handler` for method `PURGE` on path '/notify'
-router.method("PURGE", "/notify", handler);
+router.method('PURGE', '/notify', handler)
 // router to connected handlers for multiple methods and paths
-router.method(["GET", "DELETE"], ["/", "/foo"], handler1, [handler2, handler3]);
+router.method(['GET', 'DELETE'], ['/', '/foo'], handler1, [handler2, handler3])
 ```
 
 ## all(paths, ...handlers)
 
 ```js
 // routes all methods for path /all to handler
-router.all("/all", handler);
+router.all('/all', handler)
 ```
 
 ## acl|...|get|post|put|delete|...|trace(paths, ...handlers)
@@ -136,9 +133,9 @@ shortcut methods for all a HTTP methods.
 
 ```js
 // router to `handler` for method `GET` on path '/get'
-router.get("/get", handler);
+router.get('/get', handler)
 // router to connected handlers for POST method and paths
-router.post(["/", "/foo"], handler1, [handler2, handler3]);
+router.post(['/', '/foo'], handler1, [handler2, handler3])
 ```
 
 ## use(path, ...handlers)
@@ -146,21 +143,33 @@ router.post(["/", "/foo"], handler1, [handler2, handler3]);
 For path being a handler function all handlers are applied as preHook.
 
 ```js
-router.use(handler1, handler2);
+const handler1 = (req, res, next) => {
+  doesSomethingHere(req)
+  next()
+}
+const handler2 = (req, res, next) => {
+  doesSomethingHere(req)
+  next()
+}
+
+router.use(handler1, handler2)
 // is the same as calling
-router.preHook(handler1, handler2);
+router.preHook(handler1, handler2)
 ```
 
 With a path this mounts all handlers for all methods on that path.
 Most commonly used to mount routers on routers.
 
 ```js
-const sub = new Router();
-sub.mountPath = "/mount";
-sub.get("/", handler);
+const handler = (req, res) => {
+  res.end('hi')
+}
 
-const router = new Router();
-router.use(sub.mountPath, sub.handle);
+const sub = new Router()
+sub.get('/', handler)
+
+const router = new Router()
+router.use('/mount', sub)
 ```
 
 ## handle(req, res, next)
@@ -169,10 +178,10 @@ Serves a request with a response.
 Use for creating a server or mount routers on other routers.
 
 ```js
-const app = new Router();
-app.get("/", handler);
+const app = new Router()
+app.get('/', handler)
 
-http.createServer(app.handle).listen(3000);
+http.createServer(app.handle).listen(3000)
 ```
 
 ## preHook|postHook(...handlers)
@@ -182,16 +191,16 @@ Define first before setting any routes.
 
 ```js
 const handler = (name) => async (req, res) => {
-  res.body = name;
-};
-const endHandler = (req, res) => res.send();
+  res.body = name
+}
+const endHandler = (req, res) => res.send()
 
-const app = new Router();
+const app = new Router()
 // define hooks first
-app.preHook(bodyParser(), sendEtag());
-app.postHook(endHandler);
+app.preHook(bodyParser(), sendEtag())
+app.postHook(endHandler)
 // then apply routes
-app.post("/", handler("home"));
+app.post('/', handler('home'))
 ```
 
 For route `POST /` the following handlers are connected in the above setup:

--- a/package.json
+++ b/package.json
@@ -56,24 +56,24 @@
     "mnemonist": "^0.40.3"
   },
   "devDependencies": {
-    "@types/node": "^24.1.0",
+    "@types/node": "^24.3.1",
     "c8": "^10.1.3",
     "consolidate": "^1.0.4",
     "ejs": "^3.1.10",
-    "eslint": "^9.31.0",
+    "eslint": "^9.35.0",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-prettier": "^5.5.3",
+    "eslint-plugin-prettier": "^5.5.4",
     "express": "^5.1.0",
     "express-hbs": "^2.5.0",
     "globals": "^16.3.0",
     "handlebars": "^4.7.8",
-    "mocha": "^11.7.1",
+    "mocha": "^11.7.2",
     "npm-run-all": "^4.1.5",
     "rimraf": "^6.0.1",
     "shelljs": "^0.10.0",
     "sinon": "^21.0.0",
     "supertest": "^7.1.4",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   },
   "engines": {
     "node": ">=20"

--- a/src/connect.js
+++ b/src/connect.js
@@ -79,6 +79,6 @@ export const connect = (...handlers) => {
   }
 }
 
-function breakSync(req, res, next) {
+function breakSync(_req, _res, next) {
   setImmediate(next)
 }

--- a/test/Router.test.js
+++ b/test/Router.test.js
@@ -295,3 +295,57 @@ describe('Router', function () {
     })
   })
 })
+
+describe('mount routers on /', function () {
+  let app
+  before(function () {
+    app = new Router()
+    app.preHook(handleResBodyInit, send)
+    app.postHook(handleSend)
+    const router1 = new Router()
+    router1.get('/', handleName('#0.0'))
+    router1.get('/one', handleName('#1.0'))
+    router1.get('/one/:id', handleName('#1.1'))
+    router1.put('/one/:id', handleName('#1.2'))
+    router1.post('/one', handleName('#1.3'))
+    app.use('/', router1)
+    const router2 = new Router()
+    router2.get('/two', handleName('#2.0'))
+    router2.get('/two/:id', handleName('#2.1'))
+    router2.put('/two/:id', handleName('#2.2'))
+    router2.post('/two', handleName('#2.3'))
+    app.use('/', router2)
+    // router2.print()
+    app.print()
+  })
+
+  it('GET /', function () {
+    return supertest(app.handle, ST_OPTS).get('/').expect(['#0.0 GET /'])
+  })
+
+  it('GET /one', function () {
+    return supertest(app.handle, ST_OPTS).get('/one').expect(['#1.0 GET /one'])
+  })
+
+  it('POST /two', function () {
+    return supertest(app.handle, ST_OPTS)
+      .post('/two')
+      .expect(['#2.3 POST /two'])
+  })
+
+  it('GET /two/foo', function () {
+    return supertest(app.handle, ST_OPTS)
+      .get('/two/foo')
+      .expect(['#2.1 GET /two/foo'])
+  })
+
+  it('PUT /two/foo', function () {
+    return supertest(app.handle, ST_OPTS)
+      .put('/two/foo')
+      .expect(['#2.2 PUT /two/foo'])
+  })
+
+  it('POST / should "fail"', function () {
+    return supertest(app.handle, ST_OPTS).post('/').expect({})
+  })
+})

--- a/types/FindRoute.d.ts
+++ b/types/FindRoute.d.ts
@@ -1,6 +1,5 @@
-/**
- * @typedef {import('./types.js').Method} Method
- */
+/** @typedef {import('./types.js').Method} Method */
+/** @typedef {import('./types.js').Handler} Handler */
 /**
  * Radix Tree Router
  *
@@ -16,7 +15,10 @@ export class FindRoute {
      * @param {number} [size=1000]
      */
     constructor(size?: number);
+    _tree: {};
+    _paths: {};
     _cache: LRUCache<any, any> | null;
+    get paths(): {};
     /**
      * add handler by method and pathname to routing tree
      * @param {Method} method
@@ -24,6 +26,13 @@ export class FindRoute {
      * @param {Function} handler
      */
     add(method: Method, pathname: string | string[], handler: Function): void;
+    /**
+     * mount other router tree
+     * @param {string} pathname
+     * @param {FindRoute} tree
+     * @param {(handler: Handler) => Handler} connected
+     */
+    mount(pathname: string, tree: FindRoute, connected: (handler: Handler) => Handler): void;
     /**
      * print routing tree on console
      */
@@ -47,7 +56,7 @@ export class FindRoute {
         params: object;
         path: string;
     } | undefined;
-    #private;
 }
 export type Method = import("./types.js").Method;
+export type Handler = import("./types.js").Handler;
 import { LRUCache } from 'mnemonist';

--- a/types/Router.d.ts
+++ b/types/Router.d.ts
@@ -33,6 +33,10 @@ export class Router {
     /** @type {string} */
     mountPath: string;
     /**
+     * @returns {FindRoute}
+     */
+    get tree(): FindRoute;
+    /**
      * print the routing-tree from FindRoute
      */
     print(): void;
@@ -71,9 +75,10 @@ export class Router {
      * `app.use('/path', handler)` mounts `handler` on `/path/*` for ALL methods
      *
      * @param {string|string[]|Handler|Router} path
-     * @param  {...(Handler|Handler[]|undefined)} handlers
+     * @param {Handler|Handler[]|Router|undefined} routerOrHandler
+     * @param {...(Handler|Handler[]|undefined)} handlers
      */
-    use(path: string | string[] | Handler | Router, ...handlers: (Handler | Handler[] | undefined)[]): this;
+    use(path: string | string[] | Handler | Router, routerOrHandler: Handler | Handler[] | Router | undefined, ...handlers: (Handler | Handler[] | undefined)[]): this;
     /**
      * @param {string} path
      * @param {...(Handler|Handler[]|undefined)} handlers


### PR DESCRIPTION
Mounting two different routers on the very same base path disabled the first mounted router.