### PR TITLE
feat: consider prehook and posthook handlers when mounting router

### DIFF
--- a/docs/core/Router.md
+++ b/docs/core/Router.md
@@ -170,6 +170,26 @@ sub.get('/', handler)
 
 const router = new Router()
 router.use('/mount', sub)
+// GET /mount calls: sub (GET /) -> handler
+```
+
+Additional preHook and postHook handlers can be added on a router mount:
+
+```js
+const preHook = async (req, res) => {
+  res.locals = { hi: 'hi' }
+}
+const postHook = (req, res) => {
+  res.end(res.body)
+}
+
+const router = new Router()
+router.get('/', async (req, res) => {
+  res.body = `${res.locals.hi} from veloze`
+})
+
+app.use('/', preHook, router, postHook)
+// GET / calls: preHook -> router (GET /) -> postHook
 ```
 
 ## handle(req, res, next)

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "mnemonist": "^0.40.3"
   },
   "devDependencies": {
-    "@types/node": "^24.3.1",
+    "@types/node": "^24.3.3",
     "c8": "^10.1.3",
     "consolidate": "^1.0.4",
     "ejs": "^3.1.10",
@@ -65,7 +65,7 @@
     "eslint-plugin-prettier": "^5.5.4",
     "express": "^5.1.0",
     "express-hbs": "^2.5.0",
-    "globals": "^16.3.0",
+    "globals": "^16.4.0",
     "handlebars": "^4.7.8",
     "mocha": "^11.7.2",
     "npm-run-all": "^4.1.5",

--- a/test/Router.test.js
+++ b/test/Router.test.js
@@ -1,3 +1,4 @@
+import assert from 'node:assert/strict'
 import supertest from 'supertest'
 import { Router, send } from '../src/index.js'
 import { handler, asyncHandler, preHandler } from './support/index.js'
@@ -19,162 +20,203 @@ const handleName = (name) => async (req, res) => {
 }
 
 describe('Router', function () {
-  let app
-  before(function () {
-    app = new Router()
-    app.use(handleResBodyInit, send)
-    app.postHook(handleSend)
-    app
-      .get('/', handler)
-      .get('/ignore')
-      .get('/async', asyncHandler)
-      .post('/', handler)
-      .post('/mix', handler, asyncHandler)
-      .get('/users', handler, handleSendParams)
-      .get('/users/:user', handler, handleSendParams)
-      .get('/topics/:topic/books/:book', handleSendParams)
-      .get('/wildcard/:wildcard/*', handler, handleSendParams)
-      .all('/wildcard/*', handler)
-      .get('/wildcard', handler)
-
-    app.print()
-  })
-
-  describe('with paths', function () {
-    it('shall call callback handler', function () {
-      return supertest(app.handle, ST_OPTS).get('/').expect(200, ['cb: GET /'])
-    })
-
-    it('shall call async handler', function () {
-      return supertest(app.handle, ST_OPTS)
-        .get('/async')
-        .expect(200, ['async: GET /async'])
-    })
-
-    it('different method shall resolve to different handlers', function () {
-      return supertest(app.handle, ST_OPTS)
-        .post('/')
-        .expect(200, ['cb: POST /'])
-    })
-
-    it('shall cope with mix of callback and async handlers', function () {
-      return supertest(app.handle, ST_OPTS)
-        .post('/mix')
-        .expect(200, ['cb: POST /mix', 'async: POST /mix'])
-    })
-
-    it('unknown route shall return 404', function () {
-      return supertest(app.handle, ST_OPTS)
-        .get('/404')
-        .expect(404, /<h1>404<\/h1>/)
-        .expect('content-type', 'text/html; charset=utf-8')
-    })
-  })
-
-  describe('obtain params', function () {
-    it('/users', function () {
-      return supertest(app.handle, ST_OPTS).get('/users').expect(200, {})
-    })
-
-    it('/users/andi', function () {
-      return supertest(app.handle, ST_OPTS)
-        .get('/users/andi')
-        .expect(200, { user: 'andi' })
-    })
-
-    it('/users/3.12', function () {
-      return supertest(app.handle, ST_OPTS)
-        .get('/users/3.12')
-        .expect(200, { user: '3.12' })
-    })
-
-    it('malformed URI', function () {
-      return supertest(app.handle, ST_OPTS)
-        .get('/users/bad%%uri')
-        .expect(200, {})
-    })
-
-    it('/users/404/ shall not find route', function () {
-      return supertest(app.handle, ST_OPTS).get('/users/404/').expect(404)
-    })
-
-    it('/topics/programming/books/easy%20javascript', function () {
-      return supertest(app.handle, ST_OPTS)
-        .get('/topics/programming/books/easy%20javascript')
-        .expect(200, { topic: 'programming', book: 'easy javascript' })
-    })
-  })
-
-  describe('wildcard', function () {
-    it('GET /wildcard', function () {
-      return supertest(app.handle, ST_OPTS)
-        .get('/wildcard')
-        .expect(['cb: GET /wildcard'])
-    })
-
-    it('GET /wildcard/anything', function () {
-      return supertest(app.handle, ST_OPTS)
-        .get('/wildcard/anything')
-        .expect(['cb: GET /wildcard/anything'])
-    })
-
-    it('PUT /wildcard/anything', function () {
-      return supertest(app.handle, ST_OPTS)
-        .put('/wildcard/anything')
-        .expect(['cb: PUT /wildcard/anything'])
-    })
-
-    it('GET /wildcard/anything/else', function () {
-      return supertest(app.handle, ST_OPTS)
-        .get('/wildcard/anything/else')
-        .expect({ wildcard: 'anything' })
-    })
-  })
-
-  describe('.head()', function () {
-    it('GET returns a body', function () {
-      return (
-        supertest(app.handle, ST_OPTS)
-          .get('/')
-          .expect(200, '["cb: GET /"]')
-          // .expect('content-length', '13')
-          .expect('content-type', 'application/json; charset=utf-8')
-      )
-      // .then(({ body, headers }) => console.log({ headers, body }))
-    })
-
-    it('where HEAD does not', function () {
-      return supertest(app.handle, ST_OPTS)
-        .head('/')
-        .expect(200, undefined)
-        .expect('content-length', '13')
-        .expect('content-type', 'application/json; charset=utf-8')
-    })
-  })
-
-  describe('preHook and postHook', function () {
-    let router
+  describe('general', function () {
+    let app
     before(function () {
-      router = new Router({ cacheSize: 0 })
-      router.preHook(handleResBodyInit, send)
-      router.postHook(handleSend)
-      router.use(preHandler('first'), preHandler('second'))
-      router.get('/', asyncHandler)
-      router.preHook(preHandler('third'))
-      router.get('/path', handler)
+      app = new Router()
+      app.use(handleResBodyInit, send)
+      app.postHook(handleSend)
+      app
+        .get('/', handler)
+        .get('/ignore')
+        .get('/async', asyncHandler)
+        .post('/', handler)
+        .post('/mix', handler, asyncHandler)
+        .get('/users', handler, handleSendParams)
+        .get('/users/:user', handler, handleSendParams)
+        .get('/topics/:topic/books/:book', handleSendParams)
+        .get('/wildcard/:wildcard/*', handler, handleSendParams)
+        .all('/wildcard/*', handler)
+        .get('/wildcard', handler)
+
+      app.print()
     })
 
-    it('shall apply hooks', function () {
-      return supertest(router.handle)
-        .get('/')
-        .expect(200, ['first', 'second', 'async: GET /'])
+    describe('with paths', function () {
+      it('shall call callback handler', function () {
+        return supertest(app.handle, ST_OPTS)
+          .get('/')
+          .expect(200, ['cb: GET /'])
+      })
+
+      it('shall call async handler', function () {
+        return supertest(app.handle, ST_OPTS)
+          .get('/async')
+          .expect(200, ['async: GET /async'])
+      })
+
+      it('different method shall resolve to different handlers', function () {
+        return supertest(app.handle, ST_OPTS)
+          .post('/')
+          .expect(200, ['cb: POST /'])
+      })
+
+      it('shall cope with mix of callback and async handlers', function () {
+        return supertest(app.handle, ST_OPTS)
+          .post('/mix')
+          .expect(200, ['cb: POST /mix', 'async: POST /mix'])
+      })
+
+      it('unknown route shall return 404', function () {
+        return supertest(app.handle, ST_OPTS)
+          .get('/404')
+          .expect(404, /<h1>404<\/h1>/)
+          .expect('content-type', 'text/html; charset=utf-8')
+      })
     })
 
-    it('shall apply hooks for /path', function () {
-      return supertest(router.handle)
-        .get('/path')
-        .expect(200, ['first', 'second', 'third', 'cb: GET /path'])
-      // .then(({ body, headers }) => console.log({ headers, body }))
+    describe('obtain params', function () {
+      it('/users', function () {
+        return supertest(app.handle, ST_OPTS).get('/users').expect(200, {})
+      })
+
+      it('/users/andi', function () {
+        return supertest(app.handle, ST_OPTS)
+          .get('/users/andi')
+          .expect(200, { user: 'andi' })
+      })
+
+      it('/users/3.12', function () {
+        return supertest(app.handle, ST_OPTS)
+          .get('/users/3.12')
+          .expect(200, { user: '3.12' })
+      })
+
+      it('malformed URI', function () {
+        return supertest(app.handle, ST_OPTS)
+          .get('/users/bad%%uri')
+          .expect(200, {})
+      })
+
+      it('/users/404/ shall not find route', function () {
+        return supertest(app.handle, ST_OPTS).get('/users/404/').expect(404)
+      })
+
+      it('/topics/programming/books/easy%20javascript', function () {
+        return supertest(app.handle, ST_OPTS)
+          .get('/topics/programming/books/easy%20javascript')
+          .expect(200, { topic: 'programming', book: 'easy javascript' })
+      })
+    })
+
+    describe('wildcard', function () {
+      it('GET /wildcard', function () {
+        return supertest(app.handle, ST_OPTS)
+          .get('/wildcard')
+          .expect(['cb: GET /wildcard'])
+      })
+
+      it('GET /wildcard/anything', function () {
+        return supertest(app.handle, ST_OPTS)
+          .get('/wildcard/anything')
+          .expect(['cb: GET /wildcard/anything'])
+      })
+
+      it('PUT /wildcard/anything', function () {
+        return supertest(app.handle, ST_OPTS)
+          .put('/wildcard/anything')
+          .expect(['cb: PUT /wildcard/anything'])
+      })
+
+      it('GET /wildcard/anything/else', function () {
+        return supertest(app.handle, ST_OPTS)
+          .get('/wildcard/anything/else')
+          .expect({ wildcard: 'anything' })
+      })
+    })
+
+    describe('.head()', function () {
+      it('GET returns a body', function () {
+        return (
+          supertest(app.handle, ST_OPTS)
+            .get('/')
+            .expect(200, '["cb: GET /"]')
+            // .expect('content-length', '13')
+            .expect('content-type', 'application/json; charset=utf-8')
+        )
+        // .then(({ body, headers }) => console.log({ headers, body }))
+      })
+
+      it('where HEAD does not', function () {
+        return supertest(app.handle, ST_OPTS)
+          .head('/')
+          .expect(200, undefined)
+          .expect('content-length', '13')
+          .expect('content-type', 'application/json; charset=utf-8')
+      })
+    })
+
+    describe('preHook and postHook', function () {
+      let router
+      before(function () {
+        router = new Router({ cacheSize: 0 })
+        router.preHook(handleResBodyInit, send)
+        router.postHook(handleSend)
+        router.use(preHandler('first'), preHandler('second'))
+        router.get('/', asyncHandler)
+        router.preHook(preHandler('third'))
+        router.get('/path', handler)
+      })
+
+      it('shall apply hooks', function () {
+        return supertest(router.handle)
+          .get('/')
+          .expect(200, ['first', 'second', 'async: GET /'])
+      })
+
+      it('shall apply hooks for /path', function () {
+        return supertest(router.handle)
+          .get('/path')
+          .expect(200, ['first', 'second', 'third', 'cb: GET /path'])
+        // .then(({ body, headers }) => console.log({ headers, body }))
+      })
+    })
+
+    describe('.use', function () {
+      it('shall throw if more than one router given', function () {
+        assert.throws(
+          () => {
+            const r1 = new Router()
+            const r2 = new Router()
+            const app = new Router()
+            app.use(r1, r2)
+          },
+          (err) => {
+            assert.ok(err instanceof Error)
+            assert.equal(err.message, 'only one Router allowed in use()')
+            return true
+          }
+        )
+      })
+
+      it('shall mount router', async function () {
+        const preHook = async (_req, res) => {
+          res.locals = { hi: 'hi' }
+        }
+        const postHook = (_req, res) => {
+          res.end(res.body)
+        }
+
+        const router = new Router()
+        router.get('/', async (_req, res) => {
+          res.body = `${res.locals.hi} from veloze`
+        })
+
+        const app = new Router()
+        app.use('/', preHook, router, postHook)
+
+        return supertest(app.handle).get('/').expect(200, 'hi from veloze')
+      })
     })
   })
 
@@ -204,7 +246,7 @@ describe('Router', function () {
       // mount router with `use`
       router.use('/one', router2.handle, handleName('#mnt1'))
       router.use('/two', router2.handle, handleName('#mnt2'))
-      // mount router with its routPath
+      // mount router with its routePath
       router.use(router3, handleName('#mnt3'))
       // router.print()
     })
@@ -256,7 +298,7 @@ describe('Router', function () {
     })
   })
 
-  describe('mount router on /', function () {
+  describe('mount single router on /', function () {
     let app
     before(function () {
       app = new Router()
@@ -294,58 +336,60 @@ describe('Router', function () {
         .expect(['#4 POST /many'])
     })
   })
-})
 
-describe('mount routers on /', function () {
-  let app
-  before(function () {
-    app = new Router()
-    app.preHook(handleResBodyInit, send)
-    app.postHook(handleSend)
-    const router1 = new Router()
-    router1.get('/', handleName('#0.0'))
-    router1.get('/one', handleName('#1.0'))
-    router1.get('/one/:id', handleName('#1.1'))
-    router1.put('/one/:id', handleName('#1.2'))
-    router1.post('/one', handleName('#1.3'))
-    app.use('/', router1)
-    const router2 = new Router()
-    router2.get('/two', handleName('#2.0'))
-    router2.get('/two/:id', handleName('#2.1'))
-    router2.put('/two/:id', handleName('#2.2'))
-    router2.post('/two', handleName('#2.3'))
-    app.use('/', router2)
-    // router2.print()
-    app.print()
-  })
+  describe('mount multiple routers on /', function () {
+    let app
+    before(function () {
+      app = new Router()
+      app.preHook(handleResBodyInit, send)
+      app.postHook(handleSend)
+      const router1 = new Router()
+      router1.get('/', handleName('#0.0'))
+      router1.get('/one', handleName('#1.0'))
+      router1.get('/one/:id', handleName('#1.1'))
+      router1.put('/one/:id', handleName('#1.2'))
+      router1.post('/one', handleName('#1.3'))
+      app.use('/', router1)
+      const router2 = new Router()
+      router2.get('/two', handleName('#2.0'))
+      router2.get('/two/:id', handleName('#2.1'))
+      router2.put('/two/:id', handleName('#2.2'))
+      router2.post('/two', handleName('#2.3'))
+      app.use('/', router2)
+      // router2.print()
+      app.print()
+    })
 
-  it('GET /', function () {
-    return supertest(app.handle, ST_OPTS).get('/').expect(['#0.0 GET /'])
-  })
+    it('GET /', function () {
+      return supertest(app.handle, ST_OPTS).get('/').expect(['#0.0 GET /'])
+    })
 
-  it('GET /one', function () {
-    return supertest(app.handle, ST_OPTS).get('/one').expect(['#1.0 GET /one'])
-  })
+    it('GET /one', function () {
+      return supertest(app.handle, ST_OPTS)
+        .get('/one')
+        .expect(['#1.0 GET /one'])
+    })
 
-  it('POST /two', function () {
-    return supertest(app.handle, ST_OPTS)
-      .post('/two')
-      .expect(['#2.3 POST /two'])
-  })
+    it('POST /two', function () {
+      return supertest(app.handle, ST_OPTS)
+        .post('/two')
+        .expect(['#2.3 POST /two'])
+    })
 
-  it('GET /two/foo', function () {
-    return supertest(app.handle, ST_OPTS)
-      .get('/two/foo')
-      .expect(['#2.1 GET /two/foo'])
-  })
+    it('GET /two/foo', function () {
+      return supertest(app.handle, ST_OPTS)
+        .get('/two/foo')
+        .expect(['#2.1 GET /two/foo'])
+    })
 
-  it('PUT /two/foo', function () {
-    return supertest(app.handle, ST_OPTS)
-      .put('/two/foo')
-      .expect(['#2.2 PUT /two/foo'])
-  })
+    it('PUT /two/foo', function () {
+      return supertest(app.handle, ST_OPTS)
+        .put('/two/foo')
+        .expect(['#2.2 PUT /two/foo'])
+    })
 
-  it('POST / should "fail"', function () {
-    return supertest(app.handle, ST_OPTS).post('/').expect({})
+    it('POST / should "fail"', function () {
+      return supertest(app.handle, ST_OPTS).post('/').expect({})
+    })
   })
 })

--- a/test/interop/express.test.js
+++ b/test/interop/express.test.js
@@ -5,10 +5,22 @@ import { Router } from '../../src/index.js'
 describe('interop/express', function () {
   it('express shall mount a router', async function () {
     const router = new Router()
-    router.get('/', (req, res) => res.end('hi'))
+    router.get('/', (_req, res) => res.end('hi from veloze'))
+
     const app = express()
     app.use(router.handle)
 
-    await supertest(app).get('/').expect(200, 'hi')
+    await supertest(app).get('/').expect(200, 'hi from veloze')
+  })
+
+  it('shall mount and express router', async function () {
+    const router = express.Router()
+    router.get('/', (_req, res) => res.end('hi from express'))
+
+    const app = new Router()
+    // need a path here, otherwise router handler is only a preHook
+    app.use('/', router)
+
+    await supertest(app.handle).get('/').expect(200, 'hi from express')
   })
 })

--- a/types/Router.d.ts
+++ b/types/Router.d.ts
@@ -75,10 +75,9 @@ export class Router {
      * `app.use('/path', handler)` mounts `handler` on `/path/*` for ALL methods
      *
      * @param {string|string[]|Handler|Router} path
-     * @param {Handler|Handler[]|Router|undefined} routerOrHandler
-     * @param {...(Handler|Handler[]|undefined)} handlers
+     * @param {...(Handler|Handler[]|Router|undefined)} handlers
      */
-    use(path: string | string[] | Handler | Router, routerOrHandler: Handler | Handler[] | Router | undefined, ...handlers: (Handler | Handler[] | undefined)[]): this;
+    use(path: string | string[] | Handler | Router, ...handlers: (Handler | Handler[] | Router | undefined)[]): this;
     /**
      * @param {string} path
      * @param {...(Handler|Handler[]|undefined)} handlers


### PR DESCRIPTION
When mounting a router, prehook and posthook handler can be added into the .use() call.

E.g.
app.use('/path', preHook, router, postHook)